### PR TITLE
config: Remove hostPath items from the configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+config/static/single-pod/common/env.properties
+config/static/single-pod/common/secrets.properties
+

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 - serviceaccount.yaml
 - user_role.yaml
 - user_role_binding.yaml
+
+namespace: freeipa

--- a/config/rbac/scc.yaml
+++ b/config/rbac/scc.yaml
@@ -1,4 +1,4 @@
-# https://docs.openshift.com/container-platform/4.5/authentication/managing-security-context-constraints.html
+# https://docs.openshift.com/container-platform/4.8/authentication/managing-security-context-constraints.html
 # https://kubernetes-security.info/
 ---
 apiVersion: security.openshift.io/v1
@@ -9,7 +9,6 @@ metadata:
     kubernetes.io/description: Provides a Freeipa Pod deployed all in one
       just for investigation prupose.
     release.openshift.io/create-only: "true"
-allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
@@ -74,4 +73,3 @@ volumes:
   - persistentVolumeClaim
   - projected
   - secret
-  - hostPath

--- a/config/static/single-pod/pod-main.yaml
+++ b/config/static/single-pod/pod-main.yaml
@@ -133,18 +133,6 @@ spec:
       name: data
     - mountPath: /tmp
       name: systemd-tmp
-    - mountPath: /sys
-      name: systemd-sys
-      readOnly: true
-    - mountPath: /sys/fs/selinux
-      name: systemd-sys-fs-selinux
-      readOnly: true
-    - mountPath: /sys/firmware
-      name: systemd-sys-firmware
-      readOnly: true
-    - mountPath: /sys/kernel
-      name: systemd-sys-kernel
-      readOnly: true
     - mountPath: /var/run
       name: systemd-var-run
     - mountPath: /var/run/dirsrv
@@ -152,22 +140,6 @@ spec:
   volumes:
   - emptyDir: {}
     name: data
-  - hostPath:
-      path: /sys
-      type: DirectoryOrCreate
-    name: systemd-sys
-  - hostPath:
-      path: /sys/fs/selinux
-      type: Directory
-    name: systemd-sys-fs-selinux
-  - hostPath:
-      path: /sys/firmware
-      type: Directory
-    name: systemd-sys-firmware
-  - hostPath:
-      path: /sys/kernel
-      type: Directory
-    name: systemd-sys-kernel
   - emptyDir:
       medium: Memory
     name: systemd-var-run

--- a/config/static/statefulset/ephimeral/statefulset.yaml
+++ b/config/static/statefulset/ephimeral/statefulset.yaml
@@ -142,18 +142,6 @@ spec:
           name: data
         - mountPath: /tmp
           name: systemd-tmp
-        - mountPath: /sys
-          name: systemd-sys
-          readOnly: true
-        - mountPath: /sys/fs/selinux
-          name: systemd-sys-fs-selinux
-          readOnly: true
-        - mountPath: /sys/firmware
-          name: systemd-sys-firmware
-          readOnly: true
-        - mountPath: /sys/kernel
-          name: systemd-sys-kernel
-          readOnly: true
         - mountPath: /var/run
           name: systemd-var-run
         - mountPath: /var/run/dirsrv
@@ -161,22 +149,6 @@ spec:
       volumes:
       - name: data
         emptyDir: {}
-      - hostPath:
-          path: /sys
-          type: DirectoryOrCreate
-        name: systemd-sys
-      - hostPath:
-          path: /sys/fs/selinux
-          type: Directory
-        name: systemd-sys-fs-selinux
-      - hostPath:
-          path: /sys/firmware
-          type: Directory
-        name: systemd-sys-firmware
-      - hostPath:
-          path: /sys/kernel
-          type: Directory
-        name: systemd-sys-kernel
       - emptyDir:
           medium: Memory
         name: systemd-var-run

--- a/config/static/statefulset/hostpath/statefulset.yaml
+++ b/config/static/statefulset/hostpath/statefulset.yaml
@@ -142,39 +142,11 @@ spec:
           mountPath: /data
         - mountPath: /tmp
           name: systemd-tmp
-        - mountPath: /sys
-          name: systemd-sys
-          readOnly: true
-        - mountPath: /sys/fs/selinux
-          name: systemd-sys-fs-selinux
-          readOnly: true
-        - mountPath: /sys/firmware
-          name: systemd-sys-firmware
-          readOnly: true
-        - mountPath: /sys/kernel
-          name: systemd-sys-kernel
-          readOnly: true
         - mountPath: /var/run
           name: systemd-var-run
         - mountPath: /var/run/dirsrv
           name: systemd-var-dirsrv
       volumes:
-      - hostPath:
-          path: /sys
-          type: DirectoryOrCreate
-        name: systemd-sys
-      - hostPath:
-          path: /sys/fs/selinux
-          type: Directory
-        name: systemd-sys-fs-selinux
-      - hostPath:
-          path: /sys/firmware
-          type: Directory
-        name: systemd-sys-firmware
-      - hostPath:
-          path: /sys/kernel
-          type: Directory
-        name: systemd-sys-kernel
       - emptyDir:
           medium: Memory
         name: systemd-var-run

--- a/config/static/statefulset/persistent-volume/statefulset.yaml
+++ b/config/static/statefulset/persistent-volume/statefulset.yaml
@@ -139,39 +139,11 @@ spec:
           name: freeipa
         - mountPath: /tmp
           name: systemd-tmp
-        - mountPath: /sys
-          name: systemd-sys
-          readOnly: true
-        - mountPath: /sys/fs/selinux
-          name: systemd-sys-fs-selinux
-          readOnly: true
-        - mountPath: /sys/firmware
-          name: systemd-sys-firmware
-          readOnly: true
-        - mountPath: /sys/kernel
-          name: systemd-sys-kernel
-          readOnly: true
         - mountPath: /var/run
           name: systemd-var-run
         - mountPath: /var/run/dirsrv
           name: systemd-var-dirsrv
       volumes:
-      - hostPath:
-          path: /sys
-          type: DirectoryOrCreate
-        name: systemd-sys
-      - hostPath:
-          path: /sys/fs/selinux
-          type: Directory
-        name: systemd-sys-fs-selinux
-      - hostPath:
-          path: /sys/firmware
-          type: Directory
-        name: systemd-sys-firmware
-      - hostPath:
-          path: /sys/kernel
-          type: Directory
-        name: systemd-sys-kernel
       - emptyDir:
           medium: Memory
         name: systemd-var-run


### PR DESCRIPTION
- Remove from single-pod configuration.
- Remove from singleton/ephimeral configuration.
- Remove from singleton/hostpath configuration.
- Remove from singleton/persistent-volume configuration.
- Remove hostPath from SCC object.

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>