### PR TITLE
kustomize: Add support for customized container image workload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 config/static/single-pod/common/env.properties
 config/static/single-pod/common/secrets.properties
 
+# Ignore custom private variables
+private.mk
+

--- a/HELP.txt
+++ b/HELP.txt
@@ -13,3 +13,11 @@ Variables:
   OCP_NAMESPACE
     The namespace where the resources will be created.
     By default `freeipa` is used is used if nothing is specified.
+  OCP_IMAGE
+    Allow to customize the workload to be used.
+    By default it is 'quay.io/freeipa/freeipa-openshift-container:freeipa-server'
+
+  > You can put all the variables that use the Makefile into 'private.mk'
+  > and the Makefile will load at the very beginning. If you want to let some
+  > variable to be overrided from the command line, use ' ?= ' operator.
+  > If you want avoid override from the command line, use ' := ' operator.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifeq (private.mk,$(shell ls -1 private.mk 2>/dev/null))
+include private.mk
+endif
+
 # READ THIS BEFORE CHANGE
 #
 # - Use the suffix 'OCP_' for new variables to be consistent.

--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ the following layout:
          +- kustomization.yaml
          +- ... *.yaml   Infrastructure as a Code files.
 ```
+
+> For using a custom workload for the configurations, you only have to set
+> `OCP_IMAGE` to the container image reference you want to be deployed.
+

--- a/config/static/single-pod/Makefile
+++ b/config/static/single-pod/Makefile
@@ -4,5 +4,6 @@ include ../../../binaries.mk
 .PHONY: configure
 configure:
 	@$(KUSTOMIZE) edit set namespace $(OCP_NAMESPACE)
+	@$(KUSTOMIZE) edit set image workload=$(OCP_IMAGE)
 	@make -C common/ configure
 

--- a/config/static/single-pod/common/kustomizeconfig.yaml
+++ b/config/static/single-pod/common/kustomizeconfig.yaml
@@ -21,10 +21,3 @@
 varReference:
   - kind: Route
     path: spec/host
-  - kind: Pod
-    path: spec/containers/args
-
-images:
-  - name: main
-    newName: quay.io/freeipa/freeipa-openshift-container
-    newTag: freeipa-server

--- a/config/static/single-pod/kustomization.yaml
+++ b/config/static/single-pod/kustomization.yaml
@@ -20,3 +20,8 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+images:
+- name: workload
+  newName: quay.io/freeipa/freeipa-openshift-container
+  newTag: latest

--- a/config/static/single-pod/kustomizeconfig.yaml
+++ b/config/static/single-pod/kustomizeconfig.yaml
@@ -21,8 +21,3 @@
 varReference:
   - kind: Pod
     path: spec/containers/args
-
-images:
-  - name: main
-    newName: quay.io/freeipa/freeipa-openshift-container
-    newTag: freeipa-server

--- a/config/static/single-pod/pod-main.yaml
+++ b/config/static/single-pod/pod-main.yaml
@@ -14,13 +14,13 @@ spec:
   serviceAccount: freeipa
   automountServiceAccountToken: true
   containers:
-  - image: quay.io/freeipa/freeipa-openshift-container:freeipa-server
+  - image: workload
     imagePullPolicy: IfNotPresent
     name: main
     # SYSTEMD_LOG_LEVEL=debug INIT_WRAPPER=1 DEBUG_TRACE=2 PASSWORD=Secret123 NAMESPACE=freeipa SYSTEMD_OFFLINE=1 podman run -it quay.io/freeipa/freeipa-openshift-container:freeipa-server no-exit ipa-server-install -U --realm APPS.MYKUBE.KARMALABS.COM --ca-subject="CN=freeipa-11111, O=APPS.MYKUBE.KARMALABS.COM" --no-ntp --no-sshd --no-ssh --verbose
     # podman run -it -e SYSTEMD_LOG_LEVEL=debug -e INIT_WRAPPER=1 -e DEBUG_TRACE=2 -e PASSWORD=Secret123 -e NAMESPACE=freeipa -e SYSTEMD_OFFLINE=1  quay.io/freeipa/freeipa-openshift-container:freeipa-server no-exit ipa-server-install -U --realm APPS.MYKUBE.KARMALABS.COM --ca-subject="CN=freeipa-11111, O=APPS.MYKUBE.KARMALABS.COM" --no-ntp --no-sshd --no-ssh --verbose
     command:
-    - /usr/sbin/init
+    - /usr/local/sbin/init
     args:
     - no-exit
     - ipa-server-install

--- a/config/static/statefulset/ephimeral/Makefile
+++ b/config/static/statefulset/ephimeral/Makefile
@@ -5,3 +5,4 @@ include ../../../../binaries.mk
 configure:
 	@make -C ../../single-pod/common/ configure
 	@$(KUSTOMIZE) edit set namespace $(OCP_NAMESPACE)
+	@$(KUSTOMIZE) edit set image workload=$(OCP_IMAGE)

--- a/config/static/statefulset/ephimeral/kustomization.yaml
+++ b/config/static/statefulset/ephimeral/kustomization.yaml
@@ -39,3 +39,8 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+images:
+- name: workload
+  newName: quay.io/freeipa/freeipa-openshift-container
+  newTag: latest

--- a/config/static/statefulset/ephimeral/kustomizeconfig.yaml
+++ b/config/static/statefulset/ephimeral/kustomizeconfig.yaml
@@ -15,8 +15,3 @@
 varReference:
   - kind: StatefulSet
     path: spec/template/spec/containers/args
-
-images:
-  - name: main
-    newName: quay.io/freeipa/freeipa-openshift-container
-    newTag: freeipa-server

--- a/config/static/statefulset/ephimeral/statefulset.yaml
+++ b/config/static/statefulset/ephimeral/statefulset.yaml
@@ -21,13 +21,13 @@ spec:
       serviceAccount: freeipa
       automountServiceAccountToken: true
       containers:
-      - image: quay.io/freeipa/freeipa-openshift-container:freeipa-server
+      - image: workload
         imagePullPolicy: IfNotPresent
         name: main
         # SYSTEMD_LOG_LEVEL=debug INIT_WRAPPER=1 DEBUG_TRACE=2 PASSWORD=Secret123 NAMESPACE=freeipa SYSTEMD_OFFLINE=1 podman run -it quay.io/freeipa/freeipa-openshift-container:freeipa-server no-exit ipa-server-install -U --realm APPS.MYKUBE.KARMALABS.COM --ca-subject="CN=freeipa-11111, O=APPS.MYKUBE.KARMALABS.COM" --no-ntp --no-sshd --no-ssh --verbose
         # podman run -it -e SYSTEMD_LOG_LEVEL=debug -e INIT_WRAPPER=1 -e DEBUG_TRACE=2 -e PASSWORD=Secret123 -e NAMESPACE=freeipa -e SYSTEMD_OFFLINE=1  quay.io/freeipa/freeipa-openshift-container:freeipa-server no-exit ipa-server-install -U --realm APPS.MYKUBE.KARMALABS.COM --ca-subject="CN=freeipa-11111, O=APPS.MYKUBE.KARMALABS.COM" --no-ntp --no-sshd --no-ssh --verbose
         command:
-        - /usr/sbin/init
+        - /usr/local/sbin/init
         args:
         - no-exit
         - ipa-server-install

--- a/config/static/statefulset/hostpath/Makefile
+++ b/config/static/statefulset/hostpath/Makefile
@@ -5,4 +5,5 @@ include ../../../../binaries.mk
 configure:
 	@make -C ../../single-pod/common/ configure
 	@$(KUSTOMIZE) edit set namespace $(OCP_NAMESPACE)
+	$(KUSTOMIZE) edit set image workload=$(OCP_IMAGE)
 	@-oc create -f pv.yaml

--- a/config/static/statefulset/hostpath/kustomization.yaml
+++ b/config/static/statefulset/hostpath/kustomization.yaml
@@ -38,3 +38,8 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+images:
+- name: workload
+  newName: quay.io/freeipa/freeipa-openshift-container
+  newTag: latest

--- a/config/static/statefulset/hostpath/kustomizeconfig.yaml
+++ b/config/static/statefulset/hostpath/kustomizeconfig.yaml
@@ -15,3 +15,5 @@
 varReference:
   - kind: StatefulSet
     path: spec/template/spec/containers/args
+  - kind: StatefulSet
+    path: spec/template/spec/containers/env/value

--- a/config/static/statefulset/hostpath/statefulset.yaml
+++ b/config/static/statefulset/hostpath/statefulset.yaml
@@ -22,12 +22,12 @@ spec:
       automountServiceAccountToken: true
       containers:
       - name: main
-        image: quay.io/freeipa/freeipa-openshift-container:freeipa-server
+        image: workload
         imagePullPolicy: IfNotPresent
         # SYSTEMD_LOG_LEVEL=debug INIT_WRAPPER=1 DEBUG_TRACE=2 PASSWORD=Secret123 NAMESPACE=freeipa SYSTEMD_OFFLINE=1 podman run -it quay.io/freeipa/freeipa-openshift-container:freeipa-server no-exit ipa-server-install -U --realm APPS.MYKUBE.KARMALABS.COM --ca-subject="CN=freeipa-11111, O=APPS.MYKUBE.KARMALABS.COM" --no-ntp --no-sshd --no-ssh --verbose
         # podman run -it -e SYSTEMD_LOG_LEVEL=debug -e INIT_WRAPPER=1 -e DEBUG_TRACE=2 -e PASSWORD=Secret123 -e NAMESPACE=freeipa -e SYSTEMD_OFFLINE=1  quay.io/freeipa/freeipa-openshift-container:freeipa-server no-exit ipa-server-install -U --realm APPS.MYKUBE.KARMALABS.COM --ca-subject="CN=freeipa-11111, O=APPS.MYKUBE.KARMALABS.COM" --no-ntp --no-sshd --no-ssh --verbose
         command:
-        - /usr/sbin/init
+        - /usr/local/sbin/init
         args:
         - no-exit
         - ipa-server-install

--- a/config/static/statefulset/persistent-volume/Makefile
+++ b/config/static/statefulset/persistent-volume/Makefile
@@ -4,4 +4,5 @@ include ../../../../binaries.mk
 .PHONY: configure
 configure:
 	@$(KUSTOMIZE) edit set namespace $(OCP_NAMESPACE)
+	@$(KUSTOMIZE) edit set image workload=$(OCP_IMAGE)
 	@make -C ../../single-pod/common/ configure

--- a/config/static/statefulset/persistent-volume/kustomization.yaml
+++ b/config/static/statefulset/persistent-volume/kustomization.yaml
@@ -39,3 +39,8 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+images:
+- name: workload
+  newName: quay.io/freeipa/freeipa-openshift-container
+  newTag: latest

--- a/config/static/statefulset/persistent-volume/kustomizeconfig.yaml
+++ b/config/static/statefulset/persistent-volume/kustomizeconfig.yaml
@@ -15,8 +15,3 @@
 varReference:
   - kind: StatefulSet
     path: spec/template/spec/containers/args
-
-images:
-  - name: main
-    newName: quay.io/freeipa/freeipa-openshift-container
-    newTag: freeipa-server

--- a/config/static/statefulset/persistent-volume/statefulset.yaml
+++ b/config/static/statefulset/persistent-volume/statefulset.yaml
@@ -21,13 +21,13 @@ spec:
       serviceAccount: freeipa
       automountServiceAccountToken: true
       containers:
-      - image: quay.io/freeipa/freeipa-openshift-container:freeipa-server
+      - image: workload
         imagePullPolicy: IfNotPresent
         name: main
         # SYSTEMD_LOG_LEVEL=debug INIT_WRAPPER=1 DEBUG_TRACE=2 PASSWORD=Secret123 NAMESPACE=freeipa SYSTEMD_OFFLINE=1 podman run -it quay.io/freeipa/freeipa-openshift-container:freeipa-server no-exit ipa-server-install -U --realm APPS.MYKUBE.KARMALABS.COM --ca-subject="CN=freeipa-11111, O=APPS.MYKUBE.KARMALABS.COM" --no-ntp --no-sshd --no-ssh --verbose
         # podman run -it -e SYSTEMD_LOG_LEVEL=debug -e INIT_WRAPPER=1 -e DEBUG_TRACE=2 -e PASSWORD=Secret123 -e NAMESPACE=freeipa -e SYSTEMD_OFFLINE=1  quay.io/freeipa/freeipa-openshift-container:freeipa-server no-exit ipa-server-install -U --realm APPS.MYKUBE.KARMALABS.COM --ca-subject="CN=freeipa-11111, O=APPS.MYKUBE.KARMALABS.COM" --no-ntp --no-sshd --no-ssh --verbose
         command:
-        - /usr/sbin/init
+        - /usr/local/sbin/init
         args:
         - no-exit
         - ipa-server-install

--- a/variables.mk
+++ b/variables.mk
@@ -3,7 +3,7 @@ OCP_CONFIG ?= config/static/single-pod
 OCP_IMAGE_BASE ?= quay.io/freeipa
 OCP_IMAGE_NAME ?= freeipa-operator-container
 OCP_IMAGE_TAG ?= freeipa-server
-OCP_IMAGE := $(OCP_IMAGE_BASE)/$(OCP_IMAGE_NAME):$(OCP_IMAGE_TAG)
+OCP_IMAGE ?= $(OCP_IMAGE_BASE)/$(OCP_IMAGE_NAME):$(OCP_IMAGE_TAG)
 OCP_NAMESPACE ?= freeipa
 
 .PHONY: dump-vars


### PR DESCRIPTION
- Update documentation.
- Update configuration and change configurations for making them customizable.
- Assign OCP_IMAGE default value only when it is empty.

Example for using this change:

```shell
# Set up the variables
cat > private.mk <<EOF
OCP_IMAGE ?= quay.io/avisied0/freeipa-openshift-container:latest
OCP_NAMESPACE ?= freeipa
OCP_CONFIG ?= config/static/statefulset/ephimeral
SINGLEPOD_PASSWORD := Secret125

export OCP_IMAGE OCP_NAMESPACE OCP_CONFIG SINGLEPOD_PASSWORD
EOF

# Log in into the cluster
oc login kubeadmin https://...:6443

# Create configuration
make ocp-create

# And for delete it
make ocp-delete
```

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>