### PR TITLE
config: Fresh image does not finish configuration (FSETID)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ config/static/single-pod/common/secrets.properties
 # Ignore custom private variables
 private.mk
 
+# Ignore generated files for poc incubator/012-fix-to-fresh-images
+incubator/012-fix-to-fresh-images/user/configmap.yaml
+incubator/012-fix-to-fresh-images/user/pod.yaml
+incubator/012-fix-to-fresh-images/user/route.yaml

--- a/config/static/single-pod/pod-main.yaml
+++ b/config/static/single-pod/pod-main.yaml
@@ -90,6 +90,7 @@ spec:
         - DAC_OVERRIDE
         - SETUID
         - SETGID
+        - FSETID
         - KILL
         - NET_BIND_SERVICE
         - SETPCAP
@@ -99,7 +100,6 @@ spec:
         drop:
         - NET_RAW
         - SYS_CHROOT
-        - FSETID
         - AUDIT_CONTROL
         - AUDIT_READ
         - BLOCK_SUSPEND

--- a/config/static/single-pod/pod-main.yaml
+++ b/config/static/single-pod/pod-main.yaml
@@ -12,7 +12,6 @@ spec:
   dnsPolicy: ClusterFirst
   restartPolicy: Always
   serviceAccount: freeipa
-  automountServiceAccountToken: true
   containers:
   - image: workload
     imagePullPolicy: IfNotPresent
@@ -37,23 +36,27 @@ spec:
     - --no-ntp
     - --no-sshd
     - --no-ssh
-    - --verbose
+    # - --verbose
     # envFrom:
     #   - name: IPA_SERVER_HOSTNAME
     #     configMapRef:
     #       name: config
           
     env:
-    - name: KRB5_TRACE
-      value: /dev/console
-    - name: SYSTEMD_LOG_LEVEL
-      value: debug
-    - name: SYSTEMD_LOG_COLOR
-      value: "no"
-    - name: INIT_WRAPPER
+    - name: KUBERNETES
       value: "1"
-    - name: DEBUG_TRACE
-      value: "2"
+    # - name: KRB5_TRACE
+    #   value: /dev/console
+    # - name: SYSTEMD_LOG_LEVEL
+    #   value: debug
+    # - name: SYSTEMD_LOG_COLOR
+    #   value: "no"
+    # - name: INIT_WRAPPER
+    #   value: "1"
+    # - name: DEBUG_TRACE
+    #   value: "1"
+    # - name: DEBUG
+    #   value: "1"
     - name: PASSWORD
       valueFrom:
         secretKeyRef:
@@ -62,8 +65,8 @@ spec:
           optional: false
     - name: IPA_SERVER_HOSTNAME
       value: $(IPA_SERVER_HOSTNAME)
-    - name: container_uuid
-      value: b01e51533bce49ce92b6bd4680edd46e
+    # - name: container_uuid
+    #   value: b01e51533bce49ce92b6bd4680edd46e
     - name: SYSTEMD_OFFLINE
       value: "1"
     - name: SYSTEMD_NSPAWN_API_VFS_WRITABLE

--- a/config/static/single-pod/pod-main.yaml
+++ b/config/static/single-pod/pod-main.yaml
@@ -93,6 +93,20 @@ spec:
         - DAC_OVERRIDE
         - SETUID
         - SETGID
+        # Without FSETID the ccache files created has the permissions below:
+        #   -rw-rw----. 1 apache apache 3464 Nov 23 21:00 host~freeipa.apps.crc.testing@APPS.CRC.TESTING-z0WzhM
+        # With FSETID the ccache files created has the permissions below:
+        #   -rw-------. 1 ipaapi ipaapi 5068 Nov 23 21:12 host~freeipa.apps.crc.testing@APPS.CRC.TESTING-YQgWH4
+        # In both cases the /run/ipa/ccaches directory has the permissions: drwsrws---+
+        #
+        # The running process has effective uid:gid=ipaapi:ipaapi so FSETID makes the files
+        # to inherit the owner and group from the directory because the set-user-id and set-group-id
+        # are set for the directory that contain them.
+        #
+        # Without FSETID capability the ccache files created are not accessible by the wsgi process
+        # evoking the kerberos authentication to fail. It evoked sssd client installation step to
+        # fail too as in the step is invoked a RPC method on the wsgi service that has to be
+        # authenticated.
         - FSETID
         - KILL
         - NET_BIND_SERVICE

--- a/config/static/statefulset/ephimeral/statefulset.yaml
+++ b/config/static/statefulset/ephimeral/statefulset.yaml
@@ -44,23 +44,23 @@ spec:
         - --no-ntp
         - --no-sshd
         - --no-ssh
-        - --verbose
+        # - --verbose
         # envFrom:
         #   - name: IPA_SERVER_HOSTNAME
         #     configMapRef:
         #       name: config
               
         env:
-        - name: KRB5_TRACE
-          value: /dev/console
-        - name: SYSTEMD_LOG_LEVEL
-          value: debug
-        - name: SYSTEMD_LOG_COLOR
-          value: "no"
-        - name: INIT_WRAPPER
-          value: "1"
-        - name: DEBUG_TRACE
-          value: "2"
+        # - name: KRB5_TRACE
+        #   value: /dev/console
+        # - name: SYSTEMD_LOG_LEVEL
+        #   value: debug
+        # - name: SYSTEMD_LOG_COLOR
+        #   value: "no"
+        # - name: INIT_WRAPPER
+        #   value: "1"
+        # - name: DEBUG_TRACE
+        #   value: "2"
         - name: PASSWORD
           valueFrom:
             secretKeyRef:
@@ -74,7 +74,7 @@ spec:
         - name: container_uuid
           value: b01e51533bce49ce92b6bd4680edd46e
         - name: SYSTEMD_OFFLINE
-          value: "1"
+          value: "0"
         - name: SYSTEMD_NSPAWN_API_VFS_WRITABLE
           value: network
         ports:
@@ -99,6 +99,20 @@ spec:
             - DAC_OVERRIDE
             - SETUID
             - SETGID
+            # Without FSETID the ccache files created has the permissions below:
+            #   -rw-rw----. 1 apache apache 3464 Nov 23 21:00 host~freeipa.apps.crc.testing@APPS.CRC.TESTING-z0WzhM
+            # With FSETID the ccache files created has the permissions below:
+            #   -rw-------. 1 ipaapi ipaapi 5068 Nov 23 21:12 host~freeipa.apps.crc.testing@APPS.CRC.TESTING-YQgWH4
+            # In both cases the /run/ipa/ccaches directory has the permissions: drwsrws---+
+            #
+            # The running process has effective uid:gid=ipaapi:ipaapi so FSETID makes the files
+            # to inherit the owner and group from the directory because the set-user-id and set-group-id
+            # are set for the directory that contain them.
+            #
+            # Without FSETID capability the ccache files created are not accessible by the wsgi process
+            # evoking the kerberos authentication to fail. It evoked sssd client installation step to
+            # fail too as in the step is invoked a RPC method on the wsgi service that has to be
+            # authenticated.
             - FSETID
             - KILL
             - NET_BIND_SERVICE

--- a/config/static/statefulset/ephimeral/statefulset.yaml
+++ b/config/static/statefulset/ephimeral/statefulset.yaml
@@ -99,6 +99,7 @@ spec:
             - DAC_OVERRIDE
             - SETUID
             - SETGID
+            - FSETID
             - KILL
             - NET_BIND_SERVICE
             - SETPCAP
@@ -108,7 +109,6 @@ spec:
             drop:
             - NET_RAW
             - SYS_CHROOT
-            - FSETID
             - AUDIT_CONTROL
             - AUDIT_READ
             - BLOCK_SUSPEND

--- a/config/static/statefulset/hostpath/statefulset.yaml
+++ b/config/static/statefulset/hostpath/statefulset.yaml
@@ -51,30 +51,36 @@ spec:
         #       name: config
               
         env:
-        - name: KRB5_TRACE
-          value: /dev/console
-        - name: SYSTEMD_LOG_LEVEL
-          value: debug
-        - name: SYSTEMD_LOG_COLOR
-          value: "no"
-        - name: INIT_WRAPPER
-          value: "1"
-        - name: DEBUG_TRACE
-          value: "2"
+        # - name: KRB5_TRACE
+        #   value: /dev/console
+        # - name: SYSTEMD_LOG_LEVEL
+        #   value: debug
+        # - name: SYSTEMD_LOG_COLOR
+        #   value: "no"
+        # - name: INIT_WRAPPER
+        #   value: "1"
+        # - name: DEBUG_TRACE
+        #   value: "2"
         - name: PASSWORD
           valueFrom:
             secretKeyRef:
-              key: IPA_SERVER_PASSWORD
               name: freeipa
+              key: IPA_SERVER_PASSWORD
               optional: false
         - name: NAMESPACE
-          value: freeipa
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: IPA_SERVER_HOSTNAME
-          value: $(IPA_SERVER_HOSTNAME)
-        - name: container_uuid
-          value: b01e51533bce49ce92b6bd4680edd46e
+          # value: $(IPA_SERVER_HOSTNAME)
+          valueFrom:
+            configMapKeyRef:
+              name: config
+              key: IPA_SERVER_HOSTNAME
+        # - name: container_uuid
+        #   value: b01e51533bce49ce92b6bd4680edd46e
         - name: SYSTEMD_OFFLINE
-          value: "1"
+          value: "0"
         - name: SYSTEMD_NSPAWN_API_VFS_WRITABLE
           value: network
         ports:

--- a/config/static/statefulset/hostpath/statefulset.yaml
+++ b/config/static/statefulset/hostpath/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
         - --no-ntp
         - --no-sshd
         - --no-ssh
-        - --verbose
+        # - --verbose
         # envFrom:
         #   - name: IPA_SERVER_HOSTNAME
         #     configMapRef:
@@ -105,6 +105,20 @@ spec:
             - DAC_OVERRIDE
             - SETUID
             - SETGID
+            # Without FSETID the ccache files created has the permissions below:
+            #   -rw-rw----. 1 apache apache 3464 Nov 23 21:00 host~freeipa.apps.crc.testing@APPS.CRC.TESTING-z0WzhM
+            # With FSETID the ccache files created has the permissions below:
+            #   -rw-------. 1 ipaapi ipaapi 5068 Nov 23 21:12 host~freeipa.apps.crc.testing@APPS.CRC.TESTING-YQgWH4
+            # In both cases the /run/ipa/ccaches directory has the permissions: drwsrws---+
+            #
+            # The running process has effective uid:gid=ipaapi:ipaapi so FSETID makes the files
+            # to inherit the owner and group from the directory because the set-user-id and set-group-id
+            # are set for the directory that contain them.
+            #
+            # Without FSETID capability the ccache files created are not accessible by the wsgi process
+            # evoking the kerberos authentication to fail. It evoked sssd client installation step to
+            # fail too as in the step is invoked a RPC method on the wsgi service that has to be
+            # authenticated.
             - FSETID
             - KILL
             - NET_BIND_SERVICE

--- a/config/static/statefulset/hostpath/statefulset.yaml
+++ b/config/static/statefulset/hostpath/statefulset.yaml
@@ -99,6 +99,7 @@ spec:
             - DAC_OVERRIDE
             - SETUID
             - SETGID
+            - FSETID
             - KILL
             - NET_BIND_SERVICE
             - SETPCAP
@@ -108,7 +109,6 @@ spec:
             drop:
             - NET_RAW
             - SYS_CHROOT
-            - FSETID
             - AUDIT_CONTROL
             - AUDIT_READ
             - BLOCK_SUSPEND

--- a/config/static/statefulset/persistent-volume/statefulset.yaml
+++ b/config/static/statefulset/persistent-volume/statefulset.yaml
@@ -96,6 +96,7 @@ spec:
             - DAC_OVERRIDE
             - SETUID
             - SETGID
+            - FSETID
             - KILL
             - NET_BIND_SERVICE
             - SETPCAP
@@ -105,7 +106,6 @@ spec:
             drop:
             - NET_RAW
             - SYS_CHROOT
-            - FSETID
             - AUDIT_CONTROL
             - AUDIT_READ
             - BLOCK_SUSPEND

--- a/config/static/statefulset/persistent-volume/statefulset.yaml
+++ b/config/static/statefulset/persistent-volume/statefulset.yaml
@@ -44,23 +44,23 @@ spec:
         - --no-ntp
         - --no-sshd
         - --no-ssh
-        - --verbose
+        # - --verbose
         # envFrom:
         #   - name: IPA_SERVER_HOSTNAME
         #     configMapRef:
         #       name: config
               
         env:
-        - name: KRB5_TRACE
-          value: /dev/console
-        - name: SYSTEMD_LOG_LEVEL
-          value: debug
-        - name: SYSTEMD_LOG_COLOR
-          value: "no"
-        - name: INIT_WRAPPER
-          value: "1"
-        - name: DEBUG_TRACE
-          value: "2"
+        # - name: KRB5_TRACE
+        #   value: /dev/console
+        # - name: SYSTEMD_LOG_LEVEL
+        #   value: debug
+        # - name: SYSTEMD_LOG_COLOR
+        #   value: "no"
+        # - name: INIT_WRAPPER
+        #   value: "1"
+        # - name: DEBUG_TRACE
+        #   value: "2"
         - name: PASSWORD
           valueFrom:
             secretKeyRef:
@@ -74,7 +74,7 @@ spec:
         - name: container_uuid
           value: b01e51533bce49ce92b6bd4680edd46e
         - name: SYSTEMD_OFFLINE
-          value: "1"
+          value: "0"
         - name: SYSTEMD_NSPAWN_API_VFS_WRITABLE
           value: network
         ports:
@@ -96,6 +96,20 @@ spec:
             - DAC_OVERRIDE
             - SETUID
             - SETGID
+            # Without FSETID the ccache files created has the permissions below:
+            #   -rw-rw----. 1 apache apache 3464 Nov 23 21:00 host~freeipa.apps.crc.testing@APPS.CRC.TESTING-z0WzhM
+            # With FSETID the ccache files created has the permissions below:
+            #   -rw-------. 1 ipaapi ipaapi 5068 Nov 23 21:12 host~freeipa.apps.crc.testing@APPS.CRC.TESTING-YQgWH4
+            # In both cases the /run/ipa/ccaches directory has the permissions: drwsrws---+
+            #
+            # The running process has effective uid:gid=ipaapi:ipaapi so FSETID makes the files
+            # to inherit the owner and group from the directory because the set-user-id and set-group-id
+            # are set for the directory that contain them.
+            #
+            # Without FSETID capability the ccache files created are not accessible by the wsgi process
+            # evoking the kerberos authentication to fail. It evoked sssd client installation step to
+            # fail too as in the step is invoked a RPC method on the wsgi service that has to be
+            # authenticated.
             - FSETID
             - KILL
             - NET_BIND_SERVICE

--- a/incubator/003-scc-and-caps/config/pod.yaml
+++ b/incubator/003-scc-and-caps/config/pod.yaml
@@ -32,7 +32,6 @@ spec:
         capabilities:
           drop:
             # Default capabilities anyuid
-            - "FSETID"
             - "NET_RAW"
             - "SYS_CHROOT"
 
@@ -72,6 +71,7 @@ spec:
             - "DAC_OVERRIDE"
             - "NET_BIND_SERVICE"
             - "KILL"
+            - "FSETID"
 
             # No default capabilities
             - "SYS_ADMIN"
@@ -213,7 +213,6 @@ spec:
             - "SYS_CHROOT"
             # - "SETPCAP"
             # - "SETFCAP"
-            - "FSETID"
 
             # No default capabilities
             - "AUDIT_CONTROL"
@@ -254,7 +253,7 @@ spec:
 
             - "SETPCAP"
             - "SETFCAP"
-            # - "FSETID"
+            - "FSETID"
             # - "NET_RAW"
             # - "SYS_CHROOT"
 

--- a/incubator/005-deploy-in-one-pod/user/pod.yaml.envsubst
+++ b/incubator/005-deploy-in-one-pod/user/pod.yaml.envsubst
@@ -37,7 +37,6 @@ spec:
           drop:
             - NET_RAW
             - SYS_CHROOT
-            - FSETID
             - AUDIT_CONTROL
             - AUDIT_READ
             - BLOCK_SUSPEND
@@ -68,6 +67,7 @@ spec:
             - "DAC_OVERRIDE"
             - "SETUID"
             - "SETGID"
+            - "FSETID"
             - "KILL"
             - "NET_BIND_SERVICE"
 
@@ -81,7 +81,6 @@ spec:
 
       #       - "NET_RAW"
       #       - "SYS_CHROOT"
-      #       - "FSETID"
 
       #       # No default capabilities
       #       - "AUDIT_CONTROL"

--- a/incubator/012-fix-to-fresh-images/.dockerignore
+++ b/incubator/012-fix-to-fresh-images/.dockerignore
@@ -1,0 +1,6 @@
+admin/
+user/
+HELP
+Makefile
+README.md
+

--- a/incubator/012-fix-to-fresh-images/Dockerfile
+++ b/incubator/012-fix-to-fresh-images/Dockerfile
@@ -1,0 +1,10 @@
+FROM docker.io/freeipa/freeipa-server:fedora-34
+
+COPY init-data /usr/local/sbin/init
+
+# Enable debug
+# COPY gssproxy.conf /data-template/etc/gssproxy/gssproxy.conf
+
+VOLUME /data
+
+ENTRYPOINT ["/usr/local/sbin/init"]

--- a/incubator/012-fix-to-fresh-images/Dockerfile
+++ b/incubator/012-fix-to-fresh-images/Dockerfile
@@ -2,9 +2,6 @@ FROM docker.io/freeipa/freeipa-server:fedora-34
 
 COPY init-data /usr/local/sbin/init
 
-# Enable debug
-# COPY gssproxy.conf /data-template/etc/gssproxy/gssproxy.conf
-
 VOLUME /data
 
 ENTRYPOINT ["/usr/local/sbin/init"]

--- a/incubator/012-fix-to-fresh-images/HELP
+++ b/incubator/012-fix-to-fresh-images/HELP
@@ -1,0 +1,8 @@
+Available commands:
+    container-build
+    container-push
+    container-remove
+    app-validate
+    app-create
+    app-delete
+    get-info

--- a/incubator/012-fix-to-fresh-images/Makefile
+++ b/incubator/012-fix-to-fresh-images/Makefile
@@ -1,0 +1,208 @@
+# This makefile make life easier for playing with the different
+# proof of concepts.
+
+# Customizable cluster domain for deploying wherever we want
+CLUSTER_DOMAIN ?= $(shell kubectl get dnses.config.openshift.io/cluster -o json | jq -r '.spec.baseDomain' )
+REALM ?= APPS.$(shell echo $(CLUSTER_DOMAIN) | tr  '[:lower:]' '[:upper:]')
+TIMESTAMP ?= $(shell date +%Y%m%d%H%M%S)
+
+# Set the container runtime interface
+ifneq (,$(shell bash -c "command -v podman 2>/dev/null"))
+DOCKER ?= podman
+else
+ifneq (,$(shell bash -c "command -v docker 2>/dev/null"))
+DOCKER ?= docker
+else
+ifeq (,$(DOCKER))
+$(error DOCKER is not set)
+endif
+endif
+endif
+
+# linux
+ifneq (,$(shell bash -c "command -v xdg-open" 2>/dev/null))
+OPEN := xdg-open
+else
+# macos
+	ifneq (,$(shell bash -c "command -v open" 2>/dev/null))
+OPEN := open
+	else
+OPEN := echo Open
+	endif
+endif
+
+NAMESPACE=freeipa
+ifeq (,$(NAMESPACE))
+$(error Not project indicated)
+endif
+
+AWAIT_TIMEOUT?=10
+FREEIPA_containers=init-container-uuid init-uid-gid-base main
+
+APP?=$(NAMESPACE)
+CONTAINERS="$(FREEIPA_containers)"
+# Change DOCKER_BASE_IMAGE on your pipeline settings to point to your upstream
+ifeq (,$(DOCKER_BASE_IMAGE))
+$(error DOCKER_BASE_IMAGE is empty; export DOCKER_BASE_IMAGE=quay.io/namespace)
+endif
+DOCKER_TAG ?= dev-$(shell git rev-parse --short HEAD)
+DOCKER_IMAGE ?= $(DOCKER_BASE_IMAGE)/freeipa-openshift-container:$(DOCKER_TAG)
+
+
+default: help
+
+
+.PHONY: FORCE
+FORCE:
+
+.PHONY: help
+help: FORCE
+	@cat HELP
+
+.PHONY: dump-vars
+dump-vars:
+	@echo CLUSTER_DOMAIN=$(CLUSTER_DOMAIN)
+	@echo REALM=$(REALM)
+	@echo TIMESTAMP=$(TIMESTAMP)
+	@echo DOCKER=$(DOCKER)
+	@echo NAMESPACE=$(NAMESPACE)
+	@echo AWAIT_TIMEOUT=$(AWAIT_TIMEOUT)
+	@echo DOCKER_BASE_IMAGE=$(DOCKER_BASE_IMAGE)
+	@echo DOCKER_IMAGE=$(DOCKER_IMAGE)
+
+# Check that cluster domain is not empty
+.PHONY: check-cluster-domain-not-empty
+ifeq (,$(CLUSTER_DOMAIN))
+check-cluster-domain-not-empty: FORCE
+	@echo "'CLUSTER_DOMAIN' must be specified; Try 'CLUSTER_DOMAIN=my.cluster.domain.com make ...'"
+	@exit 1
+else
+check-cluster-domain-not-empty:
+endif
+
+# Check logged in OpenShift cluster
+.PHONY: check-logged-in-openshift
+ifeq (,$(shell oc whoami 2>/dev/null))
+check-logged-in-openshift: FORCE
+	@echo "ERROR: You must be logged in OpenShift cluster. Try 'oc login https://mycluster:6443' matching your cluster API endpoint"
+	@exit 1
+else
+check-logged-in-openshift:
+endif
+
+# Check APP is not empty
+.PHONY: check-app-not-empty
+ifeq (,$(APP))
+check-app-not-empty: FORCE
+	@echo "'APP' must be specified; Try 'APP=my-app-id make $0'"
+	@exit 1
+else
+check-app-not-empty:
+endif
+
+# Check DOCKER_IMAGE is not empty
+.PHONY: check-docker-image-not-empty
+ifeq (,$(DOCKER_IMAGE))
+check-docker-image-not-empty: FORCE
+	@echo "'DOCKER_IMAGE' must be defined. Eg: 'export DOCKER_IMAGE=quay.io/myusername/freeipa-server:latest'"
+	@exit 1
+else
+check-docker-image-not-empty:
+endif
+
+# Build the container image
+.PHONY: container-build
+container-build: check-docker-image-not-empty Dockerfile
+	$(DOCKER) build -t $(DOCKER_IMAGE) -f Dockerfile .
+
+# Push the container image to the container registry
+.PHONY: container-push
+container-push: check-docker-image-not-empty FORCE
+	$(DOCKER) push $(DOCKER_IMAGE)
+
+# Remove container image from the local storage
+.PHONY: container-remove
+container-remove: check-docker-image-not-empty FORCE
+	$(DOCKER) image rm $(DOCKER_IMAGE)
+
+# Validate kubernetes object for the app
+.PHONY: app-validate
+app-validate: check-logged-in-openshift check-app-not-empty validate-admin validate-user FORCE
+
+validate-admin:
+	kustomize build admin | oc create -f - --dry-run=client --validate=true
+validate-user:
+	kustomize build user | oc create -f - --dry-run=client --validate=true
+
+.PHONY: generate-manifests
+generate-manifests: user/pod.yaml user/configmap.yaml user/route.yaml FORCE
+
+user/route.yaml: user/route.yaml.envsubst FORCE
+	@REALM=$(REALM) \
+	TIMESTAMP=$(TIMESTAMP) \
+	DOCKER_IMAGE=$(DOCKER_IMAGE) \
+	CLUSTER_DOMAIN=$(CLUSTER_DOMAIN) \
+	envsubst < user/route.yaml.envsubst > user/route.yaml
+
+user/pod.yaml: user/pod.yaml.envsubst FORCE
+	@REALM=$(REALM) \
+	TIMESTAMP=$(TIMESTAMP) \
+	DOCKER_IMAGE=$(DOCKER_IMAGE) \
+	CLUSTER_DOMAIN=$(CLUSTER_DOMAIN) \
+	envsubst < user/pod.yaml.envsubst > user/pod.yaml
+
+user/configmap.yaml: user/configmap.yaml.envsubst FORCE
+	@REALM=$(REALM) \
+	TIMESTAMP=$(TIMESTAMP) \
+	DOCKER_IMAGE=$(DOCKER_IMAGE) \
+	CLUSTER_DOMAIN=$(CLUSTER_DOMAIN) \
+	envsubst < user/configmap.yaml.envsubst > user/configmap.yaml
+
+.PHONY: app-recreate
+app-recreate: app-delete app-create
+
+# Deploy the application
+.PHONY: app-create
+app-create: check-not-empty-password check-cluster-domain-not-empty check-app-not-empty check-docker-image-not-empty check-logged-in-openshift generate-manifests app-validate FORCE
+	@echo "PASSWORD=$(PASSWORD)" > user/admin-pass.txt
+	kustomize build admin | oc create -f -
+	kustomize build user | oc create -f - --as freeipa
+	oc get all -n freeipa
+
+# Delete the application from the cluster
+.PHONY: app-delete
+app-delete: check-logged-in-openshift check-app-not-empty FORCE
+	-kustomize build user | oc delete -f - --as freeipa
+	-kustomize build admin | oc delete -f -
+
+.PHONY: app-open-console
+app-open-console:
+	$(OPEN) https://$(NAMESPACE).apps.$(CLUSTER_DOMAIN)
+
+.PHONY: get-info
+get-info: check-logged-in-openshift check-app-not-empty
+	@echo ">>> oc describe pod/freeipa"
+	oc describe pod/freeipa
+	@for container in $(shell echo -n $(CONTAINERS)); do make get-info-container container=$${container}; done
+
+.PHONY: check-container-not-empty
+ifeq (,$(container))
+check-container-not-empty: FORCE
+	@[ "$(container)" != "" ] || echo "'container' must be specified: $(CONTAINERS); Try 'make container=my-container-id get-info-container'"
+	@[ "$(container)" != "" ] || exit 1
+else
+check-container-not-empty:
+endif
+
+.PHONY: check-not-empty-password
+check-not-empty-password: FORCE
+ifeq (,$(PASSWORD))
+	@echo "PASSWORD is required for deploying; eg. export PASSWORD=MyPassword123"; exit 2
+endif
+
+
+
+.PHONY: check-logged-in-openshift get-info-container
+get-info-container: check-app-not-empty check-container-not-empty
+	@echo ">>> container: $(container)"
+	@if oc wait --for=condition=ready --timeout=$(AWAIT_TIMEOUT)s pod/freeipa; then oc logs freeipa -c $(container); else oc logs -f freeipa -c $(container) --insecure-skip-tls-verify-backend=true; fi

--- a/incubator/012-fix-to-fresh-images/README.md
+++ b/incubator/012-fix-to-fresh-images/README.md
@@ -1,0 +1,57 @@
+# Prototype for getting fresh container images working
+
+This proof of concept try to detect the necessary changes
+to freeipa-openshift-container for making the fresh
+container images to deploy in Openshift. The current image
+comes from a prototype at `incubator/005-deploy-in-one-pod`.
+This directory start as a copy of 005-deploy-in-one-pod,
+and try to use a fresh image from freeipa-container to
+see what we need to change for freeipa-openshift-container.
+
+It update the configuration and clean it up for getting
+the minimal that is working.
+
+It is using ephemeral volume storage, just to detect what
+we need to change for the container so that it can
+start up again.
+
+
+## Getting started
+
+Just run:
+
+```shell
+export DOCKER_IMAGE_BASE=quay.io/<scope>
+make container-build container-push app-create
+```
+
+> If 'freeipa' namespace exists, it fails; just be aware of
+> it; you can run `make app-delete` to be sure no resources
+> exists that could evoke some error when creating them.
+
+- Where **scope** is the name of the account or organization
+  where you will publish the image. It is required to be
+  defined to avoid that by mistake it could be overwritten
+  any image into the **freeipa** organization.
+
+Later you only have to retrieve the list of objects:
+
+```shell
+oc get all
+```
+
+Access the route created:
+
+```shell
+xdg-open https://<route-hostname>
+```
+
+Where **route-hostname** is the hostname that appear for the
+Route object created.
+
+And finally to delete the configuration, you only have to run:
+
+```shell
+make app-delete
+```
+

--- a/incubator/012-fix-to-fresh-images/admin/kustomization.yaml
+++ b/incubator/012-fix-to-fresh-images/admin/kustomization.yaml
@@ -1,0 +1,23 @@
+# https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/
+#
+# Proof of Concept for reading namespace info and inject it in the ConfigMap
+#
+# Quick Start:
+#   oc kustomize . | oc create -
+#   oc describe pod/poc-01
+#   oc kustomize . | oc delete -
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- serviceaccount.yaml
+- user.yaml
+- scc-freeipa.yaml
+- rbac-cluster-role.yaml
+- rbac-cluster-role-binding.yaml
+- rbac-role.yaml
+- rbac-role-binding.yaml
+
+vars: []

--- a/incubator/012-fix-to-fresh-images/admin/namespace.yaml
+++ b/incubator/012-fix-to-fresh-images/admin/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: freeipa
+  labels:
+    app: freeipa
+  annotations:
+    openshift.io/description: "Namespace which store Freeipa resources"
+    openshift.io/display-name: "Freeipa"

--- a/incubator/012-fix-to-fresh-images/admin/rbac-cluster-role-binding.yaml
+++ b/incubator/012-fix-to-fresh-images/admin/rbac-cluster-role-binding.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: freeipa
+  namespace: freeipa
+  labels:
+    app: freeipa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: freeipa
+subjects:
+  - kind: ServiceAccount
+    name: freeipa
+    namespace: freeipa
+  - kind: User
+    name: freeipa
+    namespace: freeipa

--- a/incubator/012-fix-to-fresh-images/admin/rbac-cluster-role.yaml
+++ b/incubator/012-fix-to-fresh-images/admin/rbac-cluster-role.yaml
@@ -1,0 +1,19 @@
+---
+# create a new ClusterRole (since SCC's are cluster scoped instead of namespace
+# scoped) that will provide access to a given SCC
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: freeipa
+  namespace: freeipa
+  labels:
+    app: freeipa
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - freeipa
+    verbs:
+      - use

--- a/incubator/012-fix-to-fresh-images/admin/rbac-role-binding.yaml
+++ b/incubator/012-fix-to-fresh-images/admin/rbac-role-binding.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: freeipa
+  namespace: freeipa
+  labels:
+    app: freeipa
+roleRef:
+  kind: Role
+  name: freeipa
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: freeipa
+  - kind: User
+    name: freeipa

--- a/incubator/012-fix-to-fresh-images/admin/rbac-role.yaml
+++ b/incubator/012-fix-to-fresh-images/admin/rbac-role.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: freeipa
+  namespace: freeipa
+  labels:
+    app: freeipa
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "get", "watch", "delete", "create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["list", "get", "patch", "delete", "create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete", "create"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["delete", "create"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes", "routes/custom-host"]
+    verbs: ["create", "delete"]

--- a/incubator/012-fix-to-fresh-images/admin/scc-freeipa.yaml
+++ b/incubator/012-fix-to-fresh-images/admin/scc-freeipa.yaml
@@ -1,0 +1,81 @@
+---
+# https://docs.openshift.com/container-platform/4.5/authentication/managing-security-context-constraints.html
+# https://kubernetes-security.info/
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: freeipa
+  labels:
+    app: freeipa
+  annotations:
+    kubernetes.io/description: Provides a Freeipa Pod deployed all in one
+      just for investigation prupose.
+    release.openshift.io/create-only: "true"
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities:
+  # Default capabilities anyuid
+  - "SETUID"
+  - "SETGID"
+  - "FSETID"
+  - "SETPCAP"
+  - "DAC_OVERRIDE"
+  - "NET_RAW"
+  - "NET_BIND_SERVICE"
+  - "SYS_CHROOT"
+  - "KILL"
+  - "AUDIT_WRITE"
+  - "CHOWN"
+  - "FOWNER"
+  - "SETFCAP"
+
+  # No default capabilities
+  - "SYS_ADMIN"
+  - "SYS_RESOURCE"
+  - "MKNOD"
+allowedUnsafeSysctls:
+defaultAddCapabilities:
+  # Default capabilities anyuid
+  - "CHOWN"
+  - "FOWNER"
+  - "SETFCAP"
+
+  - "SETPCAP"
+  - "SETFCAP"
+  - "SETUID"
+  - "SETGID"
+  - "DAC_OVERRIDE"
+  - "NET_BIND_SERVICE"
+  - "KILL"
+
+  # No default capabilities
+  - "SYS_ADMIN"
+  - "SYS_RESOURCE"
+  - "MKNOD"
+fsGroup:
+  type: RunAsAny
+priority: 20
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+  # - system:serviceaccount:avisiedo-freeipa:feeipa
+  - freeipa
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+  - hostPath

--- a/incubator/012-fix-to-fresh-images/admin/serviceaccount.yaml
+++ b/incubator/012-fix-to-fresh-images/admin/serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: freeipa
+  namespace: freeipa
+  labels:
+    app: freeipa
+automountServiceAccountToken: false

--- a/incubator/012-fix-to-fresh-images/admin/user.yaml
+++ b/incubator/012-fix-to-fresh-images/admin/user.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: user.openshift.io/v1
+groups: []
+identities: []
+kind: User
+metadata:
+  name: freeipa
+  namespace: freeipa

--- a/incubator/012-fix-to-fresh-images/gssproxy.conf
+++ b/incubator/012-fix-to-fresh-images/gssproxy.conf
@@ -1,0 +1,3 @@
+[gssproxy]
+debug = true
+debug_level = 3

--- a/incubator/012-fix-to-fresh-images/gssproxy.conf
+++ b/incubator/012-fix-to-fresh-images/gssproxy.conf
@@ -1,3 +1,0 @@
-[gssproxy]
-debug = true
-debug_level = 3

--- a/incubator/012-fix-to-fresh-images/init-data
+++ b/incubator/012-fix-to-fresh-images/init-data
@@ -1,0 +1,361 @@
+#!/bin/bash
+
+# Copyright 2015--2019 Jan Pazdziora
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Initialization of /data (bind-mounted volume) from /data-template
+# we IPA server was not yet configured.
+
+set -e
+
+# Turn on tracing of this script
+test -z "$DEBUG_TRACE" || {
+	set -x
+	if [ "${DEBUG_TRACE}" == "2" ]; then
+		export SYSTEMD_LOG_LEVEL="debug"
+		export SYSTEMD_LOG_TARGET="journal+console"
+		export SYSTEMD_LOG_COLOR="no"
+		export DEBUG=1
+	fi
+}
+
+cd /
+
+function is_kubernetes
+{
+	# If KUBERNETES is not empty, return true
+	[ -n "${KUBERNETES}" ] && return 0
+
+	# This is true when 'automountServiceAccountToken: true'
+	# into the Pod spec
+	[ -e "/var/run/secrets/kubernetes.io/serviceaccount" ] && return 0
+
+	# Else return false
+	return 1
+}
+
+function set_systemd_units_private_tmp_off
+{
+       # Remove PrivateTmp=off
+       sed -i s/^PrivateTmp=on/PrivateTmp=off/g /lib/systemd/system/dirsrv@.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/ipa-custodia.service
+       sed -i s/^PrivateTmp=true/PrivateTmp=off/g /usr/lib/systemd/system/dbus-broker.service
+       sed -i s/^PrivateDevices=true/PrivateDevices=off/g /usr/lib/systemd/system/dbus-broker.service
+       sed -i 's/^ProtectSystem=full/# ProtectSystem=full/g' /usr/lib/systemd/system/dbus-broker.service
+       sed -i s/^PrivateTmp=true/PrivateTmp=off/g /lib/systemd/system/httpd.service
+
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/chronyd.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/dbus-org.freedesktop.hostname1.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/dbus-org.freedesktop.locale1.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/dbus-org.freedesktop.login1.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/dbus-org.freedesktop.oom1.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/dbus-org.freedesktop.timedate1.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/ipa-ccache-sweep.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/ipa-dnskeysyncd.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/ipa-ods-exporter.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/systemd-coredump@.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/systemd-hostnamed.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/systemd-localed.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/systemd-logind.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/systemd-oomd.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/systemd-resolved.service
+       sed -i s/^PrivateTmp=yes/PrivateTmp=off/g /lib/systemd/system/systemd-timedated.service
+
+       sed -i s/^PrivateTmp=true/PrivateTmp=off/g /lib/systemd/system/logrotate.service
+       sed -i s/^PrivateTmp=true/PrivateTmp=off/g /lib/systemd/system/named.service
+       sed -i s/^PrivateTmp=true/PrivateTmp=off/g /lib/systemd/system/httpd@.service
+}
+
+case "$1" in
+	/bin/install.sh|/bin/uninstall.sh|/bin/bash|bash)
+		exec "$@"
+	;;
+esac
+
+for i in /run/* /tmp/var/tmp/* /tmp/* ; do
+	if [ "$i" == '/run/secrets' ] ; then
+		:
+	elif [ -L "$i" -o -f "$i" ] ; then
+		rm -f "$i"
+	else
+		for j in "$i"/* ; do
+			if [ "$j" != '/tmp/var/tmp' ] ; then
+				rm -rf "$j"
+			fi
+		done
+	fi
+done
+
+/usr/local/bin/populate-volume-from-template /tmp
+
+# Workaround 1373562
+mkdir -p /run/lock
+
+DATA=/data
+DATA_TEMPLATE=/data-template
+
+mkdir -p /run/ipa /run/log $DATA/var/log/journal
+ln -s $DATA/var/log/journal /run/log/journal
+
+if [ "$1" == 'no-exit' -o -n "$DEBUG_NO_EXIT" ] ; then
+	if [ "$1" == 'no-exit' ] ; then
+		shift
+	fi
+	# Debugging:  Don't power off if IPA install/upgrade fails
+	# Create service drop-in to override `FailureAction`
+	for i in ipa-server-configure-first.service ipa-server-upgrade.service; do
+		mkdir -p /run/systemd/system/$i.d
+		echo -e "[Service]\nFailureAction=none" > /run/systemd/system/$i.d/50-no-poweroff.conf
+	done
+elif [ "$1" == 'exit-on-finished' ] ; then
+	for i in ipa-server-configure-first.service ipa-server-upgrade.service; do
+		mkdir -p /run/systemd/system/$i.d
+		# We'd like to use SuccessAction=poweroff here but it's only
+		# available in systemd 236.
+		echo -e "[Service]\nExecStartPost=/usr/bin/systemctl poweroff" > /run/systemd/system/$i.d/50-success-poweroff.conf
+	done
+	shift
+fi
+
+# Debugging:  Turn on tracing of ipa-server-configure-first script
+test -z "$DEBUG_TRACE" || touch /run/ipa/debug-trace
+
+COMMAND=
+if [ -n "$1" ] ; then
+	case "$1" in
+		ipa-server-install)
+			COMMAND="$1"
+			shift
+		;;
+		ipa-replica-install)
+			COMMAND="$1"
+			shift
+		;;
+		-*)
+			:
+		;;
+		*)
+		echo "Invocation error: command [$1] not supported." >&2
+		exit 8
+
+	esac
+fi
+if [ -z "$COMMAND" ] ; then
+	if [ -f $DATA/ipa-replica-install-options ] ; then
+		COMMAND=ipa-replica-install
+	else
+		COMMAND=ipa-server-install
+	fi
+fi
+
+if [ -n "$IPA_SERVER_INSTALL_OPTS" ] && [ "$COMMAND" != 'ipa-server-install' ] && [ "$COMMAND" != 'ipa-replica-install' ] ; then
+	echo "Invocation error: IPA_SERVER_INSTALL_OPTS should only be used with ipa-server-install or ipa-replica-install." >&2
+	exit 7
+fi
+
+OPTIONS_FILE=/run/ipa/$COMMAND-options
+
+DATA_OPTIONS_FILE=$DATA/$COMMAND-options
+touch $OPTIONS_FILE
+chmod 660 $OPTIONS_FILE
+for i in "$@" ; do
+	printf '%q\n' "$i" >> $OPTIONS_FILE
+done
+
+_HOSTNAME_IN_NEXT=false
+for i in $( cat $OPTIONS_FILE ) ; do
+	if $_HOSTNAME_IN_NEXT ; then
+		IPA_SERVER_HOSTNAME="$i"
+		break
+	fi
+        case "$i" in
+                "--hostname" | "-h")
+			_HOSTNAME_IN_NEXT=true
+                        ;;
+                --hostname=*)
+                        IPA_SERVER_HOSTNAME="${i#--hostname=}"
+                        break
+                        ;;
+	esac
+done
+
+
+
+
+
+if is_kubernetes; then
+	# Disable PrivateTmp from systemd units
+	set_systemd_units_private_tmp_off
+
+	# Container is run without FQDN set, we try to "set" it in /etc/hosts
+	if ! -q grep "$IPA_SERVER_HOSTNAME" /etc/hosts; then
+		cp /etc/hosts /etc/hosts.dist
+		sed "s/$HOSTNAME/$IPA_SERVER_HOSTNAME $IPA_SERVER_HOSTNAME. &/" /etc/hosts.dist > /etc/hosts
+		rm -f /etc/hosts.dist
+	fi
+	HOSTNAME=$IPA_SERVER_HOSTNAME
+else
+	if [ -f "$DATA/hostname" ] ; then
+		STORED_HOSTNAME="$( cat $DATA/hostname )"
+		if ! [ "$HOSTNAME" == "$STORED_HOSTNAME" ] ; then
+			# Attempt to set hostname from within container, this
+			# will pass if the container has SYS_ADMIN capability.
+			if hostname $STORED_HOSTNAME 2> /dev/null ; then
+				HOSTNAME=$( hostname )
+				if [ "$HOSTNAME" == "$STORED_HOSTNAME" ] && ! [ "$IPA_SERVER_HOSTNAME" == "$HOSTNAME" ] ; then
+					echo "Using stored hostname $STORED_HOSTNAME, ignoring $IPA_SERVER_HOSTNAME."
+				fi
+			fi
+		fi
+		IPA_SERVER_HOSTNAME=$STORED_HOSTNAME
+	fi
+
+	HOSTNAME_SHORT=${HOSTNAME%%.*}
+	if [ "$HOSTNAME_SHORT" == "$HOSTNAME" ] ; then
+		if [ -z "$IPA_SERVER_HOSTNAME" ] ; then
+			echo "Container invoked without fully-qualified hostname" >&2
+			echo "   and without specifying hostname to use." >&2
+			echo "Consider using -h FQDN option to docker run." >&2
+			exit 15
+		fi
+		# Container is run without FQDN set, we try to "set" it in /etc/hosts
+		cp /etc/hosts /etc/hosts.dist
+		sed "s/$HOSTNAME/$IPA_SERVER_HOSTNAME $IPA_SERVER_HOSTNAME. &/" /etc/hosts.dist > /etc/hosts
+		rm -f /etc/hosts.dist
+		HOSTNAME=$IPA_SERVER_HOSTNAME
+	fi
+fi
+
+if ! [ -f "$DATA/hostname" ] ; then
+	echo "$HOSTNAME" > "$DATA/hostname"
+fi
+
+function create_machine_id () {
+	# only triggers when /etc/machine-id is a symlink and not bind-mounted into
+	# the container by a container runtime.
+	if [ -L /etc/machine-id ] && [ ! -f $DATA/etc/machine-id ] ; then
+		# https://systemd.io/CONTAINER_INTERFACE/
+		# shellcheck disable=SC2154
+		if [ "${container_uuid}" != "" ]; then
+			echo "${container_uuid}" > "${DATA}/etc/machine-id"
+		else
+			dbus-uuidgen --ensure=$DATA/etc/machine-id
+		fi
+		chmod 444 $DATA/etc/machine-id
+	fi
+}
+
+if ! [ -f /etc/ipa/ca.crt ] ; then
+	if ! [ -f $DATA/ipa.csr ] ; then
+		# Do not refresh $DATA in the second stage of the external CA setup
+		/usr/local/bin/populate-volume-from-template $DATA
+		create_machine_id
+	fi
+	if [ -n "$PASSWORD" ] ; then
+		if [ "$COMMAND" == 'ipa-server-install' ] ; then
+			printf '%q\n' "--admin-password=$PASSWORD" >> $OPTIONS_FILE
+			if ! grep -sq '^--ds-password' $OPTIONS_FILE $DATA_OPTIONS_FILE ; then
+				printf '%q\n' "--ds-password=$PASSWORD" >> $OPTIONS_FILE
+			fi
+		elif [ "$COMMAND" == 'ipa-replica-install' ] ; then
+			if grep -sq '^--principal' $OPTIONS_FILE $DATA_OPTIONS_FILE ; then
+				printf '%q\n' "--admin-password=$PASSWORD" >> $OPTIONS_FILE
+			else
+				printf '%q\n' "--password=$PASSWORD" >> $OPTIONS_FILE
+			fi
+		else
+			echo "Warning: ignoring environment variable PASSWORD." >&2
+		fi
+	fi
+	if [ -n "$IPA_SERVER_INSTALL_OPTS" ] ; then
+		if [ "$COMMAND" == 'ipa-server-install' -o "$COMMAND" = 'ipa-replica-install' ] ; then
+			echo "$IPA_SERVER_INSTALL_OPTS" >> $OPTIONS_FILE
+		else
+			echo "Warning: ignoring environment variable IPA_SERVER_INSTALL_OPTS." >&2
+		fi
+	fi
+	if [ -n "$DEBUG" ] ; then
+		echo "--debug" >> $OPTIONS_FILE
+	fi
+fi
+
+# Check the volume-version of the bind-mounted volume, upgrade if it's
+# different from the one in this image.
+# The volume-upgrade file names are in format:
+#         ipa-volume-upgrade-$OLDVERSION-$NEWVERSION
+if [ -f "$DATA/volume-version" ] ; then
+	DATA_VERSION=$(cat $DATA/volume-version)
+	IMAGE_VERSION=$(cat /etc/volume-version)
+	if ! [ "$DATA_VERSION" == "$IMAGE_VERSION" ] ; then
+		if [ -x /usr/sbin/ipa-volume-upgrade-$DATA_VERSION-$IMAGE_VERSION ] ; then
+			echo "Migrating $DATA data volume version $DATA_VERSION to $IMAGE_VERSION."
+			if /usr/sbin/ipa-volume-upgrade-$DATA_VERSION-$IMAGE_VERSION ; then
+				cat /etc/volume-version > $DATA/volume-version
+			else
+				echo "Migration of $DATA volume to version $IMAGE_VERSION failed."
+				exit 13
+			fi
+		fi
+	fi
+fi
+if [ -f "$DATA/build-id" ] ; then
+	if ! cmp -s $DATA/build-id $DATA_TEMPLATE/build-id ; then
+		echo "FreeIPA server is already configured but with different version, volume update."
+		/usr/local/bin/populate-volume-from-template $DATA
+		create_machine_id
+		sha256sum -c /etc/volume-data-autoupdate 2> /dev/null | awk -F': ' '/OK$/ { print $1 }' \
+			| while read f ; do
+				rm -f "$DATA/$f"
+				if [ -e "$DATA_TEMPLATE/$f" ] ; then
+					( cd $DATA_TEMPLATE && tar cf - "./$f" ) | ( cd $DATA && tar xvf - )
+				fi
+			done
+		cat /etc/volume-data-list | while read i ; do
+			if [ -e $DATA_TEMPLATE$i ] && [ -e $DATA$i ] ; then
+				chown --reference=$DATA_TEMPLATE$i $DATA$i
+				chmod --reference=$DATA_TEMPLATE$i $DATA$i
+			fi
+		done
+		SYSTEMD_OPTS=--unit=ipa-server-upgrade.service
+	fi
+	if [ -f /etc/ipa/ca.crt ] ; then
+		rm -f "$DATA/etc/systemd/system/multi-user.target.wants/ipa-server-configure-first.service"
+	fi
+fi
+
+echo "$(date) $0 $*" >> /var/log/ipa-server-configure-first.log
+
+SHOW_LOG=${SHOW_LOG:-1}
+if [ "$SHOW_LOG" == 1 ] ; then
+	for i in /var/log/ipa-server-configure-first.log /var/log/ipa-server-run.log ; do
+		if ! [ -f $i ] ; then
+			touch $i
+		fi
+	done
+	(
+	trap '' SIGHUP
+	tail --silent -n 0 -f --retry /var/log/ipa-server-configure-first.log /var/log/ipa-server-run.log 2> /dev/null < /dev/null &
+	)
+fi
+
+if [ -n "$IPA_SERVER_IP" ] ; then
+	echo "$IPA_SERVER_IP" > /run/ipa/ipa-server-ip
+fi
+
+
+[ "$DEBUG_TRACE" != "" ] && env
+# exec /usr/sbin/init --show-status=false $SYSTEMD_OPTS
+exec /usr/sbin/init --show-status=true $SYSTEMD_OPTS
+
+exit 10

--- a/incubator/012-fix-to-fresh-images/user/configmap.yaml.envsubst
+++ b/incubator/012-fix-to-fresh-images/user/configmap.yaml.envsubst
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: freeipa
+  namespace: freeipa
+  labels:
+    app: freeipa
+data:
+  # DEBUG_TRACE: "2"
+  DEBUG_TRACE: ""
+  CLUSTER_DOMAIN: "${CLUSTER_DOMAIN}"
+  IPA_SERVER_HOSTNAME: "freeipa.apps.${CLUSTER_DOMAIN}"
+  # IPA_SERVER_IP: "10.0.135.189"
+

--- a/incubator/012-fix-to-fresh-images/user/kustomization.yaml
+++ b/incubator/012-fix-to-fresh-images/user/kustomization.yaml
@@ -1,0 +1,43 @@
+# https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/
+#
+# Proof of Concept for reading namespace info and inject it in the ConfigMap
+#
+# Quick Start:
+#   oc kustomize . | oc create -
+#   oc describe pod/poc-01
+#   oc kustomize . | oc delete -
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+secretGenerator:
+  - name: freeipa
+    namespace: freeipa
+    type: Opaque
+    envs:
+    - admin-pass.txt
+
+# vars:
+# - name: CLUSTER_DOMAIN
+#   objref: 
+#     kind: DNS
+#     name: cluster
+#     apiVersion: config.openshift.io/v1
+#   fieldref:
+#     fieldpath: spec.baseDomain
+# - name: CLUSTER_DOMAIN
+#   objref: 
+#     kind: ConfigMap
+#     name: freeipa
+#     apiVersion: v1
+#   fieldref:
+#     fieldpath: data.CLUSTER_DOMAIN
+
+resources:
+- configmap.yaml
+- pod.yaml
+- service-kerberos.yaml
+- service-web.yaml
+- service-ldap.yaml
+- route.yaml
+

--- a/incubator/012-fix-to-fresh-images/user/pod.yaml.envsubst
+++ b/incubator/012-fix-to-fresh-images/user/pod.yaml.envsubst
@@ -1,0 +1,217 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: freeipa
+  namespace: freeipa
+  labels:
+    app: freeipa
+  annotations:
+    openshift.io/scc: freeipa
+spec:
+  serviceAccountName: freeipa
+  # dnsConfig:
+  #   nameservers:
+  #     - 127.0.0.1
+  # hostAliases:
+  #   - ip: "127.0.0.1"
+  #     hostnames:
+  #       - avisiedo-freeipa.apps.permanent.idmocp.lab.eng.rdu2.redhat.com
+  #       - apps.permanent.idmocp.lab.eng.rdu2.redhat.com
+  containers:
+    - name: main
+      # Change this to the image pushed to your container registry
+      # which is stored in your DOCKER_IMAGE env variable when building
+      # with 'make container-build container-push'
+      image: ${DOCKER_IMAGE}
+      resources:
+        limits:
+          cpu: "2"
+          memory: "3Gi"
+      imagePullPolicy: Always
+      # We need 'tty: true' to see the systemd traces
+      tty: true
+      securityContext:
+        privileged: false
+        capabilities:
+          drop:
+            - NET_RAW
+            - SYS_CHROOT
+            - AUDIT_CONTROL
+            - AUDIT_READ
+            - BLOCK_SUSPEND
+            - DAC_READ_SEARCH
+            - IPC_LOCK
+            - IPC_OWNER
+            - LEASE
+            - LINUX_IMMUTABLE
+            - MAC_ADMIN
+            - MAC_OVERRIDE
+            - NET_ADMIN
+            - NET_BROADCAST
+            - SYS_BOOT
+            - SYS_MODULE
+            - SYS_NICE
+            - SYS_PACCT
+            - SYS_PTRACE
+            - SYS_RAWIO
+            - SYS_TIME
+            - SYS_TTY_CONFIG
+            - SYSLOG
+            - WAKE_ALARM
+            - SYS_RAWIO
+            - MKNOD
+          add:
+            - "CHOWN"
+            - "FOWNER"
+            - "DAC_OVERRIDE"
+            - "SETUID"
+            - "SETGID"
+            - "KILL"
+            - "NET_BIND_SERVICE"
+
+            - "SETPCAP"
+            - "SETFCAP"
+
+            # No default capabilities
+            - "SYS_ADMIN"
+            - "SYS_RESOURCE"
+
+
+      #       - "NET_RAW"
+      #       - "SYS_CHROOT"
+            - "FSETID"
+
+      #       # No default capabilities
+      #       - "AUDIT_CONTROL"
+      #       - "AUDIT_READ"
+      #       - "BLOCK_SUSPEND"
+      #       - "DAC_READ_SEARCH"
+      #       - "IPC_LOCK"
+      #       - "IPC_OWNER"
+      #       - "LEASE"
+      #       - "LINUX_IMMUTABLE"
+      #       - "MAC_ADMIN"
+      #       - "MAC_OVERRIDE"
+      #       - "NET_ADMIN"
+      #       - "NET_BROADCAST"
+      #       - "SYS_BOOT"
+      #       - "SYS_MODULE"
+      #       - "SYS_NICE"
+      #       - "SYS_PACCT"
+      #       - "SYS_PTRACE"
+      #       - "SYS_RAWIO"
+      #       - "SYS_TIME"
+      #       - "SYS_TTY_CONFIG"
+      #       - "SYSLOG"
+      #       - "WAKE_ALARM"
+      #       - "SYS_RAWIO"
+
+      #       - "MKNOD"
+
+      #     add:
+      #       # Default capabilities
+      #       - "CHOWN"
+      #       - "FOWNER"
+      #       - "DAC_OVERRIDE"
+      #       - "SETUID"
+      #       - "SETGID"
+      #       - "KILL"
+      #       - "NET_BIND_SERVICE"
+
+      #       - "SETPCAP"
+      #       - "SETFCAP"
+
+      #       # No default capabilities
+      #       - "SYS_ADMIN"
+      #       - "SYS_RESOURCE"
+
+      command: ["/usr/local/sbin/init"]
+      args:
+      # - exit-on-finished
+      - no-exit
+      - ipa-server-install
+      - -U
+      # - --hostname
+      # - avisiedo-freeipa.apps.permanent.idmocp.lab.eng.rdu2.redhat.com
+      - --realm
+      - ${REALM}
+      - --ca-subject=CN=freeipa-${TIMESTAMP}, O=${REALM}
+      - --no-ntp
+      - --no-sshd
+      - --no-ssh
+      # - --verbose
+      env:
+        - name: KUBERNETES
+          value: "1"
+        # - name: SYSTEMD_OPTS
+        #   value: "--show-status=true --unit=ipa-server-configure-first.service"
+        # - name: KRB5_TRACE
+        #   value: /dev/console
+        # - name: SYSTEMD_LOG_LEVEL
+        #   value: "debug"
+        # - name: SYSTEMD_LOG_TARGET
+        #   value: "console"
+        # - name: SYSTEMD_LOG_COLOR
+        #   value: "no"
+        # - name: INIT_WRAPPER
+        #   value: "1"
+        - name: DEBUG_TRACE
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: DEBUG_TRACE
+        - name: PASSWORD
+          valueFrom:
+            # configMapKeyRef:
+            secretKeyRef:
+              name: freeipa
+              key: PASSWORD
+        - name: IPA_SERVER_HOSTNAME
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: IPA_SERVER_HOSTNAME
+        # - name: IPA_SERVER_IP
+        #   valueFrom:
+        #     fieldRef:
+        #       fieldPath: status.podIP
+        - name: SYSTEMD_OFFLINE
+          value: "1"
+        - name: SYSTEMD_NSPAWN_API_VFS_WRITABLE
+          value: "network"
+      ports:
+        - name: http-tcp
+          protocol: TCP
+          containerPort: 80
+        - name: https-tcp
+          protocol: TCP
+          containerPort: 443
+
+      volumeMounts:
+        - name: data
+          mountPath: /data
+        - name: systemd-tmp
+          mountPath: /tmp
+        - name: systemd-var-run
+          mountPath: /var/run
+        - name: systemd-var-dirsrv
+          mountPath: /var/run/dirsrv
+
+  volumes:
+    - name: data
+      emptyDir: {}
+    - name: systemd-var-run
+      emptyDir:
+        medium: "Memory"
+    - name: systemd-var-dirsrv
+      emptyDir:
+        medium: "Memory"
+    # ----------------------------
+    - name: systemd-run-rpcbind
+      emptyDir:
+        medium: "Memory"
+
+    - name: systemd-tmp
+      emptyDir:
+        medium: "Memory"

--- a/incubator/012-fix-to-fresh-images/user/route.yaml.envsubst
+++ b/incubator/012-fix-to-fresh-images/user/route.yaml.envsubst
@@ -1,0 +1,24 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    openshift.io/host.generated: "true"
+    # https://docs.openshift.com/container-platform/4.6/networking/routes/route-configuration.html
+    haproxy.router.openshift.io/timeout: "2s"
+    haproxy.router.openshift.io/hsts_header: max-age=31536000;includeSubDomains;preload
+  labels:
+    app: freeipa
+  name: freeipa
+  namespace: freeipa
+spec:
+  host: freeipa.apps.${CLUSTER_DOMAIN}
+  port:
+    targetPort: https
+  to:
+    kind: Service
+    name: freeipa-web
+    weight: 100
+  tls:
+    termination: passthrough
+  wildcardPolicy: None

--- a/incubator/012-fix-to-fresh-images/user/service-kerberos.yaml
+++ b/incubator/012-fix-to-fresh-images/user/service-kerberos.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: freeipa
+  namespace: freeipa
+  labels:
+    app: freeipa
+spec:
+  selector:
+    app: freeipa
+  ports:
+    - name: kerberos-tcp
+      port: 88
+      targetPort: 88
+      protocol: TCP
+    - name: kerberos-udp
+      port: 88
+      targetPort: 88
+      protocol: UDP
+
+    - name: kerberos-adm-tcp
+      port: 749
+      targetPort: 749
+      protocol: TCP
+    - name: kerberos-adm-udp
+      port: 749
+      targetPort: 749
+      protocol: UDP

--- a/incubator/012-fix-to-fresh-images/user/service-ldap.yaml
+++ b/incubator/012-fix-to-fresh-images/user/service-ldap.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: freeipa-ldap
+  namespace: freeipa
+  labels:
+    app: freeipa
+spec:
+  selector:
+    app: freeipa
+  ports:
+    - name: ldap
+      port: 389
+      targetPort: ldap
+      protocol: TCP
+    - name: ldaps
+      port: 636
+      targetPort: ldaps
+      protocol: TCP

--- a/incubator/012-fix-to-fresh-images/user/service-web.yaml
+++ b/incubator/012-fix-to-fresh-images/user/service-web.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: freeipa-web
+  namespace: freeipa
+  labels:
+    app: freeipa
+spec:
+  selector:
+    app: freeipa
+  ports:
+    - name: https
+      port: 443
+      targetPort: https-tcp
+      protocol: TCP


### PR DESCRIPTION
Fix the situation that was evoking fresh images do not start:
- Add a prototype with the changes into the workload and configuration.
  - The fqdn retrieved inside the container was different between pod restarts.
  - PrivateTmp=on/yes/true was evoking errors during start up.
  - Add FSETID capability (it is dropped actually).
- Update configurations to do not drop FSETID capability.