### PR TITLE
nodes: Configuration for setting cgroup v2 into the nodes

### DIFF
--- a/config/static/nodes/cgroup-v2/README.md
+++ b/config/static/nodes/cgroup-v2/README.md
@@ -1,8 +1,22 @@
 # cgroup-v2
 
-Just apply the configuration by:
+This configuration will set cgroup-v2 for workers and master nodes.
 
 ```shell
 kustomize build config/static/nodes/cgroup-v2/ | oc create -f
+```
+
+Our scenario only need cgroup-v2 on worker nodes, so it could be more
+convenience to do the below:
+
+```shell
+oc create -f machine-config-cgroup-v2-worker.yaml
+```
+
+However, if you are using a SNO cluster, you need to apply the configuration
+to the control plane nodes (master) by:
+
+```shell
+oc create -f machine-config-cgroup-v2-master.yaml
 ```
 

--- a/config/static/nodes/cgroup-v2/README.md
+++ b/config/static/nodes/cgroup-v2/README.md
@@ -1,0 +1,14 @@
+# cgroup-v2
+
+If you have your OpenShift SNO running, you will only need to
+apply the configuration by:
+
+```shell
+oc create -f config/static/nodes/cgroup-v2/machine-config-cgroup-v2-master.yaml
+```
+
+For a no SNO running, you have to apply master and worker configuration by:
+
+```shell
+kustomize build config/static/nodes/machin
+```

--- a/config/static/nodes/cgroup-v2/README.md
+++ b/config/static/nodes/cgroup-v2/README.md
@@ -13,8 +13,10 @@ convenience to do the below:
 oc create -f machine-config-cgroup-v2-worker.yaml
 ```
 
-However, if you are using a SNO cluster, you need to apply the configuration
-to the control plane nodes (master) by:
+If in the future we move the workload to the control plane, then we
+could need to set master node too to use cgroup v2. If you are using a
+SNO (Single Node Openshift), you will need to apply the configuration to
+the master node too:
 
 ```shell
 oc create -f machine-config-cgroup-v2-master.yaml

--- a/config/static/nodes/cgroup-v2/README.md
+++ b/config/static/nodes/cgroup-v2/README.md
@@ -1,14 +1,8 @@
 # cgroup-v2
 
-If you have your OpenShift SNO running, you will only need to
-apply the configuration by:
+Just apply the configuration by:
 
 ```shell
-oc create -f config/static/nodes/cgroup-v2/machine-config-cgroup-v2-master.yaml
+kustomize build config/static/nodes/cgroup-v2/ | oc create -f
 ```
 
-For a no SNO running, you have to apply master and worker configuration by:
-
-```shell
-kustomize build config/static/nodes/machin
-```

--- a/config/static/nodes/cgroup-v2/kustomization.yaml
+++ b/config/static/nodes/cgroup-v2/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- machine-config-cgroup-v2-master.yaml
+- machine-config-cgroup-v2-worker.yaml

--- a/config/static/nodes/cgroup-v2/machine-config-cgroup-v2-master.yaml
+++ b/config/static/nodes/cgroup-v2/machine-config-cgroup-v2-master.yaml
@@ -1,0 +1,18 @@
+---
+# https://github.com/openshift/machine-config-operator/tree/master/docs
+# https://frasertweedale.github.io/blog-redhat/posts/2021-03-30-openshift-cgroupv2-systemd.html
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 99-enable-cgroupv2-masters
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  kernelArguments:
+    # https://www.freedesktop.org/software/systemd/man/systemd.html#Kernel%20Command%20Line
+    # https://www.freedesktop.org/software/systemd/man/systemd.html#systemd.unified_cgroup_hierarchy
+    - systemd.unified_cgroup_hierarchy=1
+    # https://man7.org/linux/man-pages/man7/cgroups.7.html
+    - cgroup_no_v1=all
+    # https://facebookmicrosites.github.io/psi/docs/overview
+    - psi=1

--- a/config/static/nodes/cgroup-v2/machine-config-cgroup-v2-worker.yaml
+++ b/config/static/nodes/cgroup-v2/machine-config-cgroup-v2-worker.yaml
@@ -1,0 +1,18 @@
+---
+# https://github.com/openshift/machine-config-operator/tree/master/docs
+# https://frasertweedale.github.io/blog-redhat/posts/2021-03-30-openshift-cgroupv2-systemd.html
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 99-enable-cgroupv2-workers
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  kernelArguments:
+    # https://www.freedesktop.org/software/systemd/man/systemd.html#Kernel%20Command%20Line
+    # https://www.freedesktop.org/software/systemd/man/systemd.html#systemd.unified_cgroup_hierarchy
+    - systemd.unified_cgroup_hierarchy=1
+    # https://man7.org/linux/man-pages/man7/cgroups.7.html
+    - cgroup_no_v1=all
+    # https://facebookmicrosites.github.io/psi/docs/overview
+    - psi=1


### PR DESCRIPTION
As an administrator I want a configuration to set cgroup v2 into the nodes that meet with:

* I can set the configuration with just `kustomize build config/static/nodes/cgroup-v2 | oc create -f -` 
* After the nodes are restarted they will be using cgroup v2.

Credits to @frasertweedale for his [blog](https://frasertweedale.github.io/blog-redhat/posts/2021-03-30-openshift-cgroupv2-systemd.html).