### PR TITLE
Add investigation for STOPSIGNAL instruction using kind and podman on Fedora 35

### DIFF
--- a/incubator/013-signalstop/.dockerignore
+++ b/incubator/013-signalstop/.dockerignore
@@ -1,0 +1,5 @@
+kubeconfig
+kustomization.yaml
+Makefile
+pod.yaml
+README.md

--- a/incubator/013-signalstop/Dockerfile
+++ b/incubator/013-signalstop/Dockerfile
@@ -1,4 +1,4 @@
 FROM quay.io/fedora/fedora:35
 COPY demo-signal.sh /demo-signal.sh
 STOPSIGNAL SIGINT
-ENTRYPOINT ["/demo-signal.sh"]
+CMD ["/demo-signal.sh"]

--- a/incubator/013-signalstop/Dockerfile
+++ b/incubator/013-signalstop/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/fedora/fedora:35
+COPY demo-signal.sh /demo-signal.sh
+STOPSIGNAL SIGINT
+ENTRYPOINT ["/demo-signal.sh"]

--- a/incubator/013-signalstop/Makefile
+++ b/incubator/013-signalstop/Makefile
@@ -1,0 +1,69 @@
+# https://www.redhat.com/sysadmin/replace-docker-podman-mac-revisit
+# https://www.redhat.com/sysadmin/replace-docker-podman-mac-revisited
+# If podman ps fails, try:
+# $ eval "$(ssh-agent -s)"
+# $ ssh-add /Users/$USER/.ssh/podman-machine-default
+#
+# If kind fails, review this link:
+# https://kind.sigs.k8s.io/docs/user/rootless/
+ARCH := $(shell uname -m)
+ifeq (,$(IMG_BASE))
+$(error IMG_BASE need to be set to your container registry and namespace, such as quay.io/USER)
+endif
+IMG=$(IMG_BASE)/demos:signals-$(ARCH)
+ifneq (,$(shell command -v docker 2>/dev/null))
+DOCKER ?= docker
+else
+ifneq (,$(shell command -v podman 2>/dev/null))
+DOCKER ?= podman
+endif
+endif
+
+ifeq (,$(DOCKER))
+$(error ERROR podman or docker is required)
+endif
+DEPENDENCIES := kind kustomize kubectl $(DOCKER)
+
+KUBECONFIG := kubeconfig
+export KUBECONFIG
+
+.PHONY: default
+default: help
+
+.PHONY: check-deps
+check-deps:: ## Check dependencies
+	@for item in $(DEPENDENCIES); do printf "Checking %s ... " "$${item}"; if command -v "$$item" &>/dev/null; then printf "OK\n"; else printf "FAILURE\n"; exit 0; fi; done
+
+.PHONY: kind-create
+kind-create:: ## Create a cluster with 'kind'; If this fails visit: https://kind.sigs.k8s.io/docs/user/rootless/
+	@! test -e "$(KUBECONFIG)" || { echo "ERROR:$(KUBECONFIG) exists from a previous execution"; exit 1; }
+	kind create cluster
+	kind get kubeconfig > "$(KUBECONFIG)"
+
+.PHONY: kind-delete
+kind-delete:: ## Delete the 'kind' cluster
+	kind delete cluster
+	@rm -f "$(KUBECONFIG)"
+
+.PHONY: create
+create:: ## Create the configuration by using the kind cluster
+	kustomize edit set image workload=$(IMG)
+	kustomize build . | KUBECONFIG=$(KUBECONFIG) kubectl create -f -
+
+.PHONY: delete
+delete:: ## Delete the configuration created into the kind cluster
+	kustomize build . | KUBECONFIG=$(KUBECONFIG) kubectl delete -f -
+
+.PHONY: container-build
+container-build:: ## Build container image
+	podman build -t $(IMG) -f Dockerfile .
+
+.PHONY: container-push
+container-push:: ## Push the container image to the registry
+	podman push $(IMG)
+
+# https://github.com/operator-framework/operator-sdk/blob/master/Makefile
+.PHONY: help
+help:: ## Show help about the commands
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+

--- a/incubator/013-signalstop/README.md
+++ b/incubator/013-signalstop/README.md
@@ -1,0 +1,88 @@
+# Overview
+
+This directory investigate the SIGSTOP instruction at Dockerfiles in Kubernetes 
+by creating a kind cluster using docker or podman, and deploying the demo container
+quay.io/avisied0/demos:signals
+
+This will arise if there are any difference between Openshift which is using cri-o
+or kubernetes using podman or docker as container engineers. In this particular lines
+it has been used `podman` 3.4.2 on Fedora 35.
+
+# Getting started
+
+Set the container registry scope by:
+
+```shell
+export IMG_BASE=quay.io/USER
+```
+
+Get some help anytime by:
+
+```shell
+make help
+```
+
+Check dependencies by:
+
+```shell
+make check-deps
+```
+
+Once dependencies are accomplished just do:
+
+```shell
+make kind-create
+make container-build
+make container-push
+```
+
+Now we run the proof of concept by:
+
+```shell
+make create
+export KUBECONFIG=$PWD/kubeconfig
+kubectl wait --for=condition=Ready pod/demo-signals
+kubectl logs pod/demo-signals -f &
+kubectl delete pod/demo-signals
+```
+
+For podman v3.4.2 it is got the below output:
+
+```raw
+kubectl delete pod/demo-signals
+pod "demo-signals" deleted
+Exiting by SIGINT
+```
+
+For releasing the resources, we delete the cluster created with kind by:
+
+```shell
+make kind-delete
+```
+
+# Results
+
+We can see that kubernetes using podman is behaving as expected, by
+passing through the SIGSTOP instructions, and sending the SIGSTOP signal
+indicated into the Dockerfile, so that Openshift which is using cri-o
+and runc under the hood is not passing through the SIGSTOP instruction
+and it is always sending SIGTERM.
+
+# Wrap up
+
+- `kind` using podman is passing through the information at SIGSTOP instruction
+  as expecting.
+
+# Knowledgements
+
+Thanks to Fraser Tweedel who pushed me on this to dig more, you inspire me
+and make me to go beyond my starting thoughts.
+
+# References
+
+- https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html#stopping-systemd-workloads-in-openshift
+
+- https://kubectl.docs.kubernetes.io/installation/kustomize/source/
+- https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-binary-with-curl-on-linux
+- https://kind.sigs.k8s.io/docs/user/quick-start/#installing-from-source
+- https://kind.sigs.k8s.io/docs/user/rootless/

--- a/incubator/013-signalstop/demo-signal.sh
+++ b/incubator/013-signalstop/demo-signal.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
-function trap_sigint { echo "Exiting by SIGINT";  exit 0; }
-function trap_sigterm { echo "Exiting by SIGTERM"; exit 0; }
-function trap_sigusr1 { echo "Exiting by SIGUSR1"; exit 0; }
-function trap_sigrtmin3 { echo "Exiting by SIGRTMIN+3"; exit 0; }
+function trap_signal {
+  local signal="$1"
+  echo -e "\nExiting by ${signal}" >&2
+  exit 0
+}
 
-trap trap_sigint SIGINT
-trap trap_sigterm SIGTERM
-trap trap_sigusr1 SIGUSR1
-trap trap_sigrtmin3 "SIGRTMIN+3"
+for signal in SIGINT SIGTERM SIGUSR1 "SIGRTMIN+3"
+do
+  trap "trap_signal '${signal}'" "${signal}"
+done
 
 while true; do
     echo -n "."

--- a/incubator/013-signalstop/demo-signal.sh
+++ b/incubator/013-signalstop/demo-signal.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+function trap_sigint { echo "Exiting by SIGINT";  exit 0; }
+function trap_sigterm { echo "Exiting by SIGTERM"; exit 0; }
+function trap_sigusr1 { echo "Exiting by SIGUSR1"; exit 0; }
+function trap_sigrtmin3 { echo "Exiting by SIGRTMIN+3"; exit 0; }
+
+trap trap_sigint SIGINT
+trap trap_sigterm SIGTERM
+trap trap_sigusr1 SIGUSR1
+trap trap_sigrtmin3 "SIGRTMIN+3"
+
+while true; do sleep 1; done

--- a/incubator/013-signalstop/demo-signal.sh
+++ b/incubator/013-signalstop/demo-signal.sh
@@ -10,4 +10,7 @@ trap trap_sigterm SIGTERM
 trap trap_sigusr1 SIGUSR1
 trap trap_sigrtmin3 "SIGRTMIN+3"
 
-while true; do sleep 1; done
+while true; do
+    echo -n "."
+    sleep 1
+done

--- a/incubator/013-signalstop/kustomization.yaml
+++ b/incubator/013-signalstop/kustomization.yaml
@@ -1,0 +1,33 @@
+# https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/
+#
+# Proof of Concept for reading namespace info and inject it in the ConfigMap
+#
+# Quick Start:
+#   oc kustomize . | oc create -
+#   oc describe pod/demo-signals
+#   oc kustomize . | oc delete -
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# vars:
+# - name: CLUSTER_DOMAIN
+#   objref: 
+#     kind: DNS
+#     name: cluster
+#     apiVersion: config.openshift.io/v1
+#   fieldref:
+#     fieldpath: spec.baseDomain
+# - name: CLUSTER_DOMAIN
+#   objref: 
+#     kind: ConfigMap
+#     name: freeipa
+#     apiVersion: v1
+#   fieldref:
+#     fieldpath: data.CLUSTER_DOMAIN
+
+resources:
+- pod.yaml
+images:
+- name: workload
+  newName: quay.io/avisied0/demos
+  newTag: signals-aarch64

--- a/incubator/013-signalstop/kustomization.yaml
+++ b/incubator/013-signalstop/kustomization.yaml
@@ -9,22 +9,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# vars:
-# - name: CLUSTER_DOMAIN
-#   objref: 
-#     kind: DNS
-#     name: cluster
-#     apiVersion: config.openshift.io/v1
-#   fieldref:
-#     fieldpath: spec.baseDomain
-# - name: CLUSTER_DOMAIN
-#   objref: 
-#     kind: ConfigMap
-#     name: freeipa
-#     apiVersion: v1
-#   fieldref:
-#     fieldpath: data.CLUSTER_DOMAIN
-
 resources:
 - pod.yaml
 images:

--- a/incubator/013-signalstop/pod.yaml
+++ b/incubator/013-signalstop/pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-signals
+  labels:
+    name: demo-signals
+spec:
+  containers:
+  - name: demo-signals
+    image: workload
+    imagePullPolicy: "Always"
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    command:
+      - "/demo-signal.sh"
+
+

--- a/incubator/README.md
+++ b/incubator/README.md
@@ -15,3 +15,7 @@ Contents:
 - **[003-scc-and-caps](003-scc-and-caps/README.md)**: Security Container Constraints and capabilities.
 - **[005-deploy-in-one-pod](005-deploy-in-one-pod/README.md)**:
   Proof of concept which deploy a Pod with Freeipa and expose the web interface.
+- **[013-signalstop](013-signalstop/README.md)**:
+  Proof of concept for testing SIGSTOP instruction by using `kind` and `podman` (or `docker`),
+  to check if the STOPSIGNAL instruction is propagated as expected. This complete the
+  blog article at [Stopping systemd workloads in Openshift](https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html#stopping-systemd-workloads-in-openshift).


### PR DESCRIPTION
- Add Dockerfile to build container for the investigation which contains STOPSIGNAL instruction.
- Script for trap several signals.
- Pod configuration.
- kustomize configuration.
- Makefile for automating the steps.
- Documentation at `README.md` file.